### PR TITLE
Simplify code copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,39 +88,18 @@ Ensure you're running [the `pulse:check` command](https://laravel.com/docs/10.x/
 ## Add to your dashboard
 
 Integrate the card into your Pulse dashboard by [publish the vendor view](https://laravel.com/docs/10.x/pulse#dashboard-customization).
-and then modifying the `dashboard.blade.php` file:
+and then adding the following to the `dashboard.blade.php` file:
 
-```diff
-<x-pulse>
-    <livewire:pulse.servers cols="full" />
-    
-+   <livewire:database cols='6' title="Active threads" :values="['Threads_connected', 'Threads_running']" :graphs="[
-+       'avg' => ['Threads_connected' => '#ffffff', 'Threads_running' => '#3c5dff'],
-+   ]" />
+```html
+<livewire:database cols='6' title="Active threads" :values="['Threads_connected', 'Threads_running']" :graphs="[
+    'avg' => ['Threads_connected' => '#ffffff', 'Threads_running' => '#3c5dff'],
+]" />
 
-+   <livewire:database cols='6' title="Connections" :values="['Connections', 'Max_used_connections']"  />
+<livewire:database cols='6' title="Connections" :values="['Connections', 'Max_used_connections']" />
 
-+   <livewire:database cols='full' title="Innodb" :values="['Innodb_buffer_pool_reads', 'Innodb_buffer_pool_read_requests', 'Innodb_buffer_pool_pages_total']" :graphs="[
-+       'avg' => ['Innodb_buffer_pool_reads' => '#ffffff', 'Innodb_buffer_pool_read_requests' => '#3c5dff'],
-+   ]" />
-
-    <livewire:pulse.usage cols="4" rows="2" />
-
-    <livewire:pulse.queues cols="4" />
-
-    <livewire:pulse.cache cols="4" />
-
-    <livewire:pulse.slow-queries cols="8" />
-
-    <livewire:pulse.exceptions cols="6" />
-
-    <livewire:pulse.slow-requests cols="6" />
-
-    <livewire:pulse.slow-jobs cols="6" />
-
-    <livewire:pulse.slow-outgoing-requests cols="6" />
-
-</x-pulse>
+<livewire:database cols='full' title="Innodb" :values="['Innodb_buffer_pool_reads', 'Innodb_buffer_pool_read_requests', 'Innodb_buffer_pool_pages_total']" :graphs="[
+    'avg' => ['Innodb_buffer_pool_reads' => '#ffffff', 'Innodb_buffer_pool_read_requests' => '#3c5dff'],
+]" />
 ```
 
 And that's it! Enjoy enhanced visibility into your database status on your Pulse dashboard.


### PR DESCRIPTION
When copying the code earlier, it included extra `+` signs. I added this for ease of copying, as others may encounter the same issue.