### PR TITLE
format numbers for humans

### DIFF
--- a/resources/views/livewire/database-card.blade.php
+++ b/resources/views/livewire/database-card.blade.php
@@ -51,7 +51,7 @@
                             @foreach($values as $value)
                                 <div class="flex flex-col justify-center @sm:block">
                                 <span class="text-xl uppercase font-bold text-gray-700 dark:text-gray-300 tabular-nums">
-                                    {{ $connection->$value }}
+                                    {{ \Illuminate\Support\Number::format($connection->$value) }}
                                 </span>
                                     <span class="text-xs uppercase font-bold text-gray-500 dark:text-gray-400">
                                     {{ str_replace('_', ' ', ucfirst($value)) }}


### PR DESCRIPTION
This uses the [Number helper](https://laravel.com/docs/10.x/helpers#numbers) to format large numbers for easier human readability

# Before

![SCR-20240402-inlm](https://github.com/maantje/pulse-database/assets/784333/156928e1-bb47-4764-9b3d-9d0c143bbccb)

![SCR-20240402-inmj](https://github.com/maantje/pulse-database/assets/784333/7f1eeb8c-4010-4809-83a7-920926edc46a)

# After

![SCR-20240402-inia](https://github.com/maantje/pulse-database/assets/784333/175d4417-5136-4166-bd7f-2541fec5c25f)
![SCR-20240402-inop](https://github.com/maantje/pulse-database/assets/784333/a27b4266-0449-4b32-bbcf-a6d23e0b539d)
